### PR TITLE
Pydantic >=2.8 to >=2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.9, <3.13"
 wherobots-python-dbapi = "^0.7.1"
-pydantic = "^2.8.2"
+pydantic = "^2.3"
 
 [tool.poetry.group.dev.dependencies]
 apache-airflow = "^2.7.0"


### PR DESCRIPTION
requires pydantic > 2.8 is too high, we should try to tolerant as low version as possible to co-exist with other libraries in user's Airflow environment