### PR TITLE
Better authentication errors when API key isn't configured

### DIFF
--- a/airflow_providers_wherobots/hooks/rest_api.py
+++ b/airflow_providers_wherobots/hooks/rest_api.py
@@ -30,8 +30,8 @@ class WherobotsAuth(AuthBase):
         self.api_key = api_key
 
     def __call__(self, r: PreparedRequest):
-        # modify and return the request
-        r.headers["X-API-Key"] = self.api_key
+        if self.api_key:
+            r.headers["X-API-Key"] = self.api_key
         return r
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-providers-wherobots"
-version = "1.1.2"
+version = "1.2.0"
 description = "Airflow extension for communicating with Wherobots Cloud"
 authors = ["zongsi.zhang <zongsi@wherobots.com>"]
 readme = "README.md"


### PR DESCRIPTION
See BUG-421. This lets a more informative 401 error occur, rather than a Python exception preparing the request because the header has an invalid None value.