### PR TITLE
Release v1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-providers-wherobots"
-version = "1.2.0"
+version = "1.2.1"
 description = "Airflow extension for communicating with Wherobots Cloud"
 authors = ["zongsi.zhang <zongsi@wherobots.com>"]
 readme = "README.md"


### PR DESCRIPTION
Changes:
- https://github.com/wherobots/airflow-providers-wherobots/commit/bde3734b6333f2bab40e6283a7b589c5f8fe1216

We wrongly created an argument `xcom_push` which conflicts with the method name in BaseOperators, it blocks user to push xcom states.
