### PR TITLE
WIP Lower the boundary of airflow version to 2.6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4311,13 +4311,13 @@ watchdog = ["watchdog"]
 
 [[package]]
 name = "wherobots-python-dbapi"
-version = "0.10.1"
+version = "0.11.0"
 description = "Python DB-API driver for Wherobots DB"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "wherobots_python_dbapi-0.10.1-py3-none-any.whl", hash = "sha256:4d6866fb42e67785c681c26a3d49c53ad60c90a29d7ce420bdd8eb5aa7fd93a0"},
-    {file = "wherobots_python_dbapi-0.10.1.tar.gz", hash = "sha256:bf16b1b4fdf8ba82597ee1d46b302a359e7e4dc850a5b804ee021c349b110b04"},
+    {file = "wherobots_python_dbapi-0.11.0-py3-none-any.whl", hash = "sha256:a79029fae2e8a7fe256a16d6ab272b239363d4a857a4cd536b17d96933ff2127"},
+    {file = "wherobots_python_dbapi-0.11.0.tar.gz", hash = "sha256:aee2794fe30038c303d2755aa815f9f344870215d6298a324f0b5a0f0cfae018"},
 ]
 
 [package.dependencies]
@@ -4587,4 +4587,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <3.13"
-content-hash = "45286e72b9c5745ab279cdb3c0d9f56574f2f6d6960c0ed5ebeac8dbc12b33de"
+content-hash = "0dd6a4fb535dd3d4829fcd23de642828e8d923b6f7757a001ecaddb8b2838b87"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.8, <3.13"
-wherobots-python-dbapi = "^0.10.1"
+wherobots-python-dbapi = "^0.11.0"
 pydantic = "^2.3"
 
 [tool.poetry.group.dev.dependencies]
-apache-airflow = "^2.7.0"
+apache-airflow = "^2.6.0"
 pytest = "^8.1.1"
 requests-mock = "^1.12.1"
 aioresponses = "^0.7.4"


### PR DESCRIPTION
Message from Customer

> Hi 
[@Furqaan Khan](https://wherobots.slack.com/team/U05JKUZJE9F)
 (Wherobots),
We encountered an issue while trying to install two new dependencies introduced by the Agnostic operator on Azure ADF managed Airflows. When we installed these dependencies, it caused the Airflow environment to break. After removing the libraries, the environment was restored, indicating a compatibility issue between the new versions and our current setup (Apache Airflow version 2.6.3).
Upon investigating the issue, we reviewed the package’s source repository. We checked the [pyproject.toml file](https://github.com/wherobots/airflow-providers-wherobots/blob/main/pyproject.toml) and the earliest release [commit](https://github.com/wherobots/airflow-providers-wherobots/blob/c31fde25df5333d3d2c655f47fea806ebff2f53a/pyproject.toml). We found that all versions of the provider, including the latest version 1.2.1, require Airflow 2.7.0.
Since we are still using Airflow 2.6.3, we may continue to face compatibility issues. Could you share any guidance or potential solutions for managing this version mismatch?
For reference, here’s the related GitHub issue: [OvertureMaps/tf-data-platform#1151](https://github.com/OvertureMaps/tf-data-platform/issues/1151).
Looking forward to your insights.
Thank you