### PR TITLE
Migrate GitHub Actions to Depot runners

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -11,7 +11,7 @@ jobs:
   pypi-publish:
     needs: run-tests
     name: Upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-small
     environment:
       name: pypi
       url: https://pypi.org/p/airflow-providers-wherobots

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   execute-tests:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Migrate pypi-publish.yaml job to depot-ubuntu-24.04-small for lightweight PyPI publishing operations
- Migrate run_tests.yaml job to depot-ubuntu-24.04 for test execution (unit and integration tests)

## Test plan
- [ ] Verify workflows execute successfully with new Depot runners
- [ ] Confirm PyPI publishing continues to work properly
- [ ] Validate test execution performance and reliability