### PR TITLE
fix: use `is None` for region presence checks (fast follow #57)

### DIFF
--- a/airflow_providers_wherobots/hooks/rest_api.py
+++ b/airflow_providers_wherobots/hooks/rest_api.py
@@ -118,7 +118,7 @@ class WherobotsRestAPIHook(BaseHook):
         # Normalize enum -> value, pass strings through, and omit region
         # entirely when unset so the API applies the org default.
         region_value = region.value if isinstance(region, Region) else region
-        params = {"region": region_value} if region_value else {}
+        params = {"region": region_value} if region_value is not None else {}
         resp_json = self._api_call(
             "POST",
             "/runs",

--- a/airflow_providers_wherobots/operators/__init__.py
+++ b/airflow_providers_wherobots/operators/__init__.py
@@ -18,7 +18,7 @@ def warn_for_default_region(
     is provided, returns ``None`` so the API applies the organization's
     configured default region — only set ``region`` to override that default.
     """
-    if not region:
+    if region is None:
         logger.info(
             "No region specified; the Wherobots API will use your organization's "
             "configured default region. Pass `region` to override it."

--- a/tests/unit_tests/hooks/test_rest_api.py
+++ b/tests/unit_tests/hooks/test_rest_api.py
@@ -162,6 +162,22 @@ class TestWherobotsRestAPIHook:
             hook.create_run(payload=create_payload, region="byoc-acme-us-east-1")
 
     @responses.activate
+    def test_create_run_passes_empty_string_region(self, test_default_conn) -> None:
+        """An empty-string region is forwarded to the API, not silently dropped."""
+        test_run: Run = helpers.run_factory.build()
+        url = f"https://{test_default_conn.host}/runs"
+        create_payload = {"name": test_run.name, "timeoutSeconds": 5000}
+        responses.add(
+            responses.POST,
+            url,
+            json=test_run.model_dump(mode="json"),
+            match=[matchers.query_string_matcher("region=")],
+            status=HTTPStatus.OK,
+        )
+        with WherobotsRestAPIHook() as hook:
+            hook.create_run(payload=create_payload, region="")
+
+    @responses.activate
     def test_get_run_logs(self, test_default_conn) -> None:
         """
         Test the get_run method

--- a/tests/unit_tests/operators/test_helpers.py
+++ b/tests/unit_tests/operators/test_helpers.py
@@ -15,3 +15,8 @@ class TestWarnForDefaultRegion:
 
     def test_string_is_passed_through(self) -> None:
         assert warn_for_default_region("byoc-acme-us-east-1") == "byoc-acme-us-east-1"
+
+    def test_empty_string_is_passed_through(self) -> None:
+        # "" is a caller mistake worth surfacing to the API, not silently
+        # dropped as if no region were provided.
+        assert warn_for_default_region("") == ""

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "airflow-providers-wherobots"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Fast follow to #57 addressing the two blocking review comments from salty-hambot.

Both call sites used falsy checks (`if not region` / `if region_value`) to decide whether to omit `region`, which silently swallows an empty-string region:

- `airflow_providers_wherobots/hooks/rest_api.py` — `create_run` dropped the `region` query param when `""` was passed.
- `airflow_providers_wherobots/operators/__init__.py` — `warn_for_default_region` returned `None` for `""`.

An empty string is a caller mistake worth surfacing to the API, not papering over. Both checks are now explicit `is None`.

## Also included

- `uv.lock` synced to `version = "1.6.1"` (drift from #56's release prep — lock was at 1.6.0, pyproject was at 1.6.1; `uv` re-synced it on test run).

## Test plan
```
uv run pytest tests/unit_tests/   -> 45 passed
```

New tests:
- `test_empty_string_is_passed_through` (helper)
- `test_create_run_passes_empty_string_region` (hook)