### PR TITLE
chore: bump wherobots-python-dbapi pin to >=0.28.0 and version to 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "airflow-providers-wherobots"
-version = "1.6.1"
+version = "1.7.0"
 description = "Airflow extension for communicating with Wherobots Cloud"
 authors = [{ name = "zongsi.zhang", email = "zongsi@wherobots.com" }]
 requires-python = ">=3.10, <3.13"
 readme = "README.md"
 dependencies = [
-    "wherobots-python-dbapi>=0.26.1",
+    "wherobots-python-dbapi>=0.28.0",
     "pydantic~=2.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "airflow-providers-wherobots"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -136,7 +136,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = "~=2.3" },
-    { name = "wherobots-python-dbapi", specifier = ">=0.26.1" },
+    { name = "wherobots-python-dbapi", specifier = ">=0.28.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2869,7 +2869,7 @@ wheels = [
 
 [[package]]
 name = "wherobots-python-dbapi"
-version = "0.26.1"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cbor2" },
@@ -2883,9 +2883,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ba/c16051ad0a58e4a7b7dd34dd117b60b49715e9f152fed738df62f98c8f5b/wherobots_python_dbapi-0.26.1.tar.gz", hash = "sha256:df6369766437fd316a79e48b98c3f8e9a9b297059e19df80bc7c075a5a148439", size = 20086, upload-time = "2026-04-21T17:07:08.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/65/6404abb4c2b8304b7653852797e8084114a2b943bcd6ba2abf2369ce41b8/wherobots_python_dbapi-0.28.0.tar.gz", hash = "sha256:6c157677e6d7078a395f02a185df83379fb9a8749908947ae71db22e0d0d9af9", size = 21050, upload-time = "2026-05-28T18:21:11.703Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/e1/df621d2e411346c3b000a72a77e07f3a4d38ce46dc880145130eb29b44ad/wherobots_python_dbapi-0.26.1-py3-none-any.whl", hash = "sha256:c1e2f67f0d6c0110078c51a11df591f01b86f7b18eec4727e05beeefcc572457", size = 23124, upload-time = "2026-04-21T17:07:06.466Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/03/8adb81b736b30e6a70e87d3de90bb7a054be5ca664ed41303ade99fceecf/wherobots_python_dbapi-0.28.0-py3-none-any.whl", hash = "sha256:bfefa57ffac357beab5106ebdfd4a629d1ae8bb64c0137a3450767a321b2bbbf", size = 24167, upload-time = "2026-05-28T18:21:10.381Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `wherobots-python-dbapi` floor in `pyproject.toml` from `>=0.26.1` to `>=0.28.0`.
- Bump `airflow-providers-wherobots` version from `1.6.1` to `1.7.0` (release vehicle for #57).
- Refresh `uv.lock` so the package actually resolves to dbapi `0.28.0`.

## Why now
PR #57 widened `region`/`runtime` to `str | enum | None` on `WherobotsRunOperator` / `WherobotsSqlOperator` and stopped injecting hardcoded `aws-us-west-2`/`tiny` defaults, but left the dbapi floor at `>=0.26.1` so the PR's CI could resolve before dbapi v0.28.0 was published. v0.28.0 [is now on PyPI](https://pypi.org/project/wherobots-python-dbapi/0.28.0/) and includes the matching client-side change — strings (BYOC included) pass through to the API as-is, and omitted values let the API apply the org's configured default.

Without this bump, an installer of `airflow-providers-wherobots>=1.6.1` could still resolve to the old enum-only dbapi 0.26.1 / 0.27.0 and crash on raw BYOC region strings via `Region(value)`.

## Compatibility
- Existing DAGs passing `Region.X` / `Runtime.X` enums continue to work — their `.value` is used at the request boundary.
- Existing DAGs that omitted `region` / `runtime` will now follow the org's configured default instead of the previous hardcoded `aws-us-west-2` / `tiny`. If you depended on the old hardcoded values, pass them explicitly.

## Test plan
- [x] Locally installed against staging dbapi 0.28.0; `tests/unit_tests/operators/test_helpers.py::TestWarnForDefaultRegion` passes (3/3) and region/runtime-focused operator tests pass (9 collected).
- [x] Hook-level smoke against staging: `WherobotsRestAPIHook.create_run` with no region → `aws-eu-west-1` (org default); raw BYOC string `aws-us-east-1-djrm9bs9uf` → passthrough; `Region` enum → `.value` resolved.
- [ ] After merge + tag + release, confirm `pypi-publish.yaml` succeeds and `pip index versions airflow-providers-wherobots` shows `1.7.0`.
- [ ] Confirm prod-targeted integration suite stays green on main post-release.