### PR TITLE
feat: emit the X-Wherobots-Client attribution header (WBC-819)

### DIFF
--- a/airflow_providers_wherobots/client_attribution.py
+++ b/airflow_providers_wherobots/client_attribution.py
@@ -1,0 +1,61 @@
+"""
+Client attribution via the shared ``X-Wherobots-Client`` header.
+
+``X-Wherobots-Client`` is an ordered, append-only, comma-separated list of
+hops modelled on ``X-Forwarded-For``: the leftmost hop is the ORIGIN client
+and every component appends its own hop on the right. It lets Wherobots
+services attribute a request to the client it came from.
+
+This provider is an origin client: an Airflow DAG is where the request enters
+the Wherobots client ecosystem, so it emits ``client=airflow;ver=<version>``
+as the leftmost hop. Where the provider goes through another Wherobots client
+(the Python DB-API driver, for the SQL hook), that client appends its own hop
+to the right, producing e.g.
+``client=airflow;ver=1.7.0, client=dbapi;ver=0.28.1``.
+
+The header is advisory: it is client-asserted and informational only, and must
+never influence authentication or authorization.
+"""
+
+from importlib import metadata
+from typing import Dict, Final
+
+from airflow_providers_wherobots.hooks.base import PACKAGE_NAME
+
+# Canonical name of the shared, cross-service client-chain header.
+WHEROBOTS_CLIENT_HEADER: Final[str] = "X-Wherobots-Client"
+
+# Canonical, stable vocabulary token for this client. Renaming it splits its
+# history in the platform's attribution analytics, so it must not change.
+CLIENT_TOKEN: Final[str] = "airflow"
+
+# Sentinel used when the installed distribution's version can't be resolved
+# (e.g. the provider is imported from a source tree that was never installed).
+UNKNOWN_VERSION: Final[str] = "unknown"
+
+# Commas separate hops and semicolons separate a hop's fields, so neither may
+# appear inside a value.
+_DELIMITERS = str.maketrans({",": "_", ";": "_"})
+
+
+def _resolve_provider_version() -> str:
+    """Return the installed provider version, or ``unknown`` if unavailable."""
+    try:
+        return metadata.version(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return UNKNOWN_VERSION
+
+
+# Resolved once at import: `importlib.metadata.version` scans the installed
+# package database on each call, and the version can't change within a process.
+PROVIDER_VERSION: Final[str] = _resolve_provider_version()
+
+# This provider's single hop, e.g. `client=airflow;ver=1.7.0`.
+CLIENT_HOP: Final[str] = (
+    f"client={CLIENT_TOKEN};ver={PROVIDER_VERSION.translate(_DELIMITERS)}"
+)
+
+
+def client_attribution_header() -> Dict[str, str]:
+    """Return the ``X-Wherobots-Client`` header carrying this provider's hop."""
+    return {WHEROBOTS_CLIENT_HEADER: CLIENT_HOP}

--- a/airflow_providers_wherobots/hooks/rest_api.py
+++ b/airflow_providers_wherobots/hooks/rest_api.py
@@ -7,7 +7,6 @@ from functools import cached_property
 from typing import Any, Optional, Dict, Union
 
 import requests
-from importlib import metadata
 from airflow.version import version as airflow_version
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
@@ -16,7 +15,10 @@ from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
 from wherobots.db import Region
 
-from airflow_providers_wherobots.client_attribution import client_attribution_header
+from airflow_providers_wherobots.client_attribution import (
+    PROVIDER_VERSION,
+    client_attribution_header,
+)
 from airflow_providers_wherobots.hooks.base import (
     DEFAULT_CONN_ID,
     PACKAGE_NAME,
@@ -74,10 +76,9 @@ class WherobotsRestAPIHook(BaseHook):
 
     @cached_property
     def user_agent_header(self):
-        try:
-            package_version = metadata.version(PACKAGE_NAME)
-        except metadata.PackageNotFoundError:
-            package_version = "unknown"
+        # PROVIDER_VERSION is the same lookup with the same `unknown` fallback,
+        # resolved once at import instead of on each first access here.
+        package_version = PROVIDER_VERSION
         python_version = platform.python_version()
         system = platform.system().lower()
         header_value = (

--- a/airflow_providers_wherobots/hooks/rest_api.py
+++ b/airflow_providers_wherobots/hooks/rest_api.py
@@ -16,6 +16,7 @@ from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
 from wherobots.db import Region
 
+from airflow_providers_wherobots.client_attribution import client_attribution_header
 from airflow_providers_wherobots.hooks.base import (
     DEFAULT_CONN_ID,
     PACKAGE_NAME,
@@ -85,6 +86,15 @@ class WherobotsRestAPIHook(BaseHook):
         )
         return {"User-Agent": header_value}
 
+    @cached_property
+    def default_headers(self) -> Dict[str, str]:
+        """Headers sent on every REST API request.
+
+        The hook talks to the platform directly, so it is the origin hop of the
+        advisory ``X-Wherobots-Client`` chain.
+        """
+        return {**self.user_agent_header, **client_attribution_header()}
+
     def _api_call(
         self,
         method: str,
@@ -100,7 +110,7 @@ class WherobotsRestAPIHook(BaseHook):
             json=payload,
             auth=auth,
             params=params,
-            headers=self.user_agent_header,
+            headers=self.default_headers,
         )
         try:
             resp.raise_for_status()

--- a/airflow_providers_wherobots/hooks/rest_api.py
+++ b/airflow_providers_wherobots/hooks/rest_api.py
@@ -12,13 +12,14 @@ from airflow.version import version as airflow_version
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
 from requests import PreparedRequest, Response
-from requests.adapters import HTTPAdapter, Retry
+from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
 from wherobots.db import Region
 
 from airflow_providers_wherobots.hooks.base import (
     DEFAULT_CONN_ID,
-    PACKAGE_NAME, WherobotsRetry,
+    PACKAGE_NAME,
+    WherobotsRetry,
 )
 from airflow_providers_wherobots.wherobots.models import (
     Run,
@@ -59,7 +60,6 @@ class WherobotsRestAPIHook(BaseHook):
             backoff_factor=self.retry_min_delay,
             status_forcelist=[500, 502, 503, 504, 429],
         )
-
 
     def __enter__(self):
         return self

--- a/airflow_providers_wherobots/hooks/sql.py
+++ b/airflow_providers_wherobots/hooks/sql.py
@@ -2,7 +2,8 @@
 Hook for Wherobots' Spatial SQL API interface.
 """
 
-from typing import Optional, Union
+import inspect
+from typing import Any, Dict, Final, Optional, Union
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from wherobots.db import Connection as WDBConnection, connect
@@ -15,7 +16,23 @@ from wherobots.db.region import Region
 from wherobots.db.runtime import Runtime
 from wherobots.db.session_type import SessionType
 
+from airflow_providers_wherobots.client_attribution import client_attribution_header
 from airflow_providers_wherobots.hooks.base import DEFAULT_CONN_ID
+
+# This hook reaches the platform through the Python DB-API driver rather than
+# directly. The driver appends its own `client=dbapi;ver=...` hop to any
+# inbound `X-Wherobots-Client` chain, so handing it our hop via `extra_headers`
+# keeps Airflow as the leftmost (origin) hop instead of letting the driver look
+# like the origin.
+#
+# `extra_headers` is newer than this provider's `wherobots-python-dbapi>=0.28.0`
+# floor, so it is probed rather than assumed: against an older driver the
+# provider still works and simply loses the Airflow hop. Delete this probe and
+# pass the argument unconditionally once the floor is raised to a release that
+# has it.
+_CONNECT_SUPPORTS_EXTRA_HEADERS: Final[bool] = (
+    "extra_headers" in inspect.signature(connect).parameters
+)
 
 
 class WherobotsSqlHook(DbApiHook):  # type: ignore[misc]
@@ -50,6 +67,11 @@ class WherobotsSqlHook(DbApiHook):  # type: ignore[misc]
         self,
         runtime: Optional[Union[str, Runtime]] = None,
     ) -> WDBConnection:
+        attribution: Dict[str, Any] = (
+            {"extra_headers": client_attribution_header()}
+            if _CONNECT_SUPPORTS_EXTRA_HEADERS
+            else {}
+        )
         return connect(
             host=self._conn.host,
             api_key=self._conn.password,
@@ -60,6 +82,7 @@ class WherobotsSqlHook(DbApiHook):  # type: ignore[misc]
             read_timeout=self.read_timeout,
             force_new=self.force_new,
             session_type=self.session_type,
+            **attribution,
         )
 
     def get_conn(self) -> WDBConnection:

--- a/airflow_providers_wherobots/hooks/sql.py
+++ b/airflow_providers_wherobots/hooks/sql.py
@@ -3,6 +3,7 @@ Hook for Wherobots' Spatial SQL API interface.
 """
 
 import inspect
+import logging
 from typing import Any, Dict, Final, Optional, Union
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook
@@ -16,7 +17,10 @@ from wherobots.db.region import Region
 from wherobots.db.runtime import Runtime
 from wherobots.db.session_type import SessionType
 
-from airflow_providers_wherobots.client_attribution import client_attribution_header
+from airflow_providers_wherobots.client_attribution import (
+    WHEROBOTS_CLIENT_HEADER,
+    client_attribution_header,
+)
 from airflow_providers_wherobots.hooks.base import DEFAULT_CONN_ID
 
 # This hook reaches the platform through the Python DB-API driver rather than
@@ -33,6 +37,17 @@ from airflow_providers_wherobots.hooks.base import DEFAULT_CONN_ID
 _CONNECT_SUPPORTS_EXTRA_HEADERS: Final[bool] = (
     "extra_headers" in inspect.signature(connect).parameters
 )
+
+if not _CONNECT_SUPPORTS_EXTRA_HEADERS:
+    # Losing attribution is silent by design -- it must never fail a
+    # connection -- but silent and undiscoverable are different things. This is
+    # the one line that explains an Airflow-driven query showing up in the
+    # platform's analytics attributed to the driver instead of to Airflow.
+    logging.getLogger(__name__).debug(
+        "Installed wherobots-python-dbapi has no `extra_headers` argument; "
+        "omitting the %s hop for SQL connections.",
+        WHEROBOTS_CLIENT_HEADER,
+    )
 
 
 class WherobotsSqlHook(DbApiHook):  # type: ignore[misc]

--- a/tests/unit_tests/hooks/test_rest_api.py
+++ b/tests/unit_tests/hooks/test_rest_api.py
@@ -240,8 +240,8 @@ class TestWherobotsRestAPIHook:
                 return_value="3.8.10",
             )
             mocker.patch(
-                "airflow_providers_wherobots.hooks.rest_api.metadata.version",
-                return_value="1.2.3",
+                "airflow_providers_wherobots.hooks.rest_api.PROVIDER_VERSION",
+                "1.2.3",
             )
             assert hook.user_agent_header == {
                 "User-Agent": f"airflow-providers-wherobots/1.2.3 os/linux python/3.8.10 airflow/{airflow.__version__}"

--- a/tests/unit_tests/hooks/test_rest_api.py
+++ b/tests/unit_tests/hooks/test_rest_api.py
@@ -4,6 +4,7 @@ Test the REST API hooks.
 
 import json
 from http import HTTPStatus
+from importlib import metadata
 
 import airflow
 import requests
@@ -13,10 +14,15 @@ from pytest_mock import MockerFixture
 from responses import matchers
 from wherobots.db import Runtime, Region
 
+from airflow_providers_wherobots.client_attribution import (
+    CLIENT_HOP,
+    WHEROBOTS_CLIENT_HEADER,
+)
 from airflow_providers_wherobots.hooks.rest_api import (
     WherobotsAuth,
     WherobotsRestAPIHook,
 )
+from airflow_providers_wherobots.hooks.base import PACKAGE_NAME
 from airflow_providers_wherobots.wherobots.models import (
     Run,
     LogsResponse,
@@ -194,6 +200,31 @@ class TestWherobotsRestAPIHook:
         )
         with WherobotsRestAPIHook() as hook:
             hook.cancel_run(run_id=test_run.ext_id)
+
+    @responses.activate
+    def test_api_call_sends_client_attribution_header(self, test_default_conn) -> None:
+        """Every REST call carries this provider's origin hop."""
+        url = f"https://{test_default_conn.host}/test"
+        responses.add(
+            responses.GET,
+            url,
+            json={},
+            status=HTTPStatus.OK,
+            match=[matchers.header_matcher({WHEROBOTS_CLIENT_HEADER: CLIENT_HOP})],
+        )
+        with WherobotsRestAPIHook() as hook:
+            hook._api_call("GET", "/test")
+
+        sent = responses.calls[0].request.headers[WHEROBOTS_CLIENT_HEADER]
+        assert sent == f"client=airflow;ver={metadata.version(PACKAGE_NAME)}"
+
+    def test_default_headers_keep_the_user_agent(self, test_default_conn) -> None:
+        """Client attribution is additive: the User-Agent is still sent."""
+        with WherobotsRestAPIHook() as hook:
+            assert hook.default_headers == {
+                **hook.user_agent_header,
+                WHEROBOTS_CLIENT_HEADER: CLIENT_HOP,
+            }
 
     def test_user_agent(self, test_default_conn, mocker: MockerFixture) -> None:
         """

--- a/tests/unit_tests/hooks/test_sql.py
+++ b/tests/unit_tests/hooks/test_sql.py
@@ -6,10 +6,15 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from airflow.models import Connection
+from pytest_mock import MockerFixture
 from wherobots.db.region import Region
 from wherobots.db.runtime import Runtime
 from wherobots.db.session_type import SessionType
 
+from airflow_providers_wherobots.client_attribution import (
+    CLIENT_HOP,
+    WHEROBOTS_CLIENT_HEADER,
+)
 from airflow_providers_wherobots.hooks.sql import WherobotsSqlHook
 
 
@@ -37,3 +42,35 @@ class TestWherobotsSqlHook:
             force_new=True,
             session_type=SessionType.SINGLE,
         )
+
+    @mock.patch("airflow_providers_wherobots.hooks.sql.connect")
+    def test_get_conn_passes_client_attribution_to_the_driver(
+        self,
+        mock_connect: MagicMock,
+        test_default_conn: Connection,
+        mocker: MockerFixture,
+    ):
+        """Our hop goes to the driver, which appends its own hop to the right."""
+        mocker.patch(
+            "airflow_providers_wherobots.hooks.sql._CONNECT_SUPPORTS_EXTRA_HEADERS",
+            True,
+        )
+        WherobotsSqlHook().get_conn()
+        assert mock_connect.call_args.kwargs["extra_headers"] == {
+            WHEROBOTS_CLIENT_HEADER: CLIENT_HOP
+        }
+
+    @mock.patch("airflow_providers_wherobots.hooks.sql.connect")
+    def test_get_conn_omits_client_attribution_on_older_drivers(
+        self,
+        mock_connect: MagicMock,
+        test_default_conn: Connection,
+        mocker: MockerFixture,
+    ):
+        """A driver without `extra_headers` still connects, just unattributed."""
+        mocker.patch(
+            "airflow_providers_wherobots.hooks.sql._CONNECT_SUPPORTS_EXTRA_HEADERS",
+            False,
+        )
+        WherobotsSqlHook().get_conn()
+        assert "extra_headers" not in mock_connect.call_args.kwargs

--- a/tests/unit_tests/hooks/test_sql.py
+++ b/tests/unit_tests/hooks/test_sql.py
@@ -20,7 +20,21 @@ from airflow_providers_wherobots.hooks.sql import WherobotsSqlHook
 
 class TestWherobotsSqlHook:
     @mock.patch("airflow_providers_wherobots.hooks.sql.connect")
-    def test_get_conn(self, mock_connect: MagicMock, test_default_conn: Connection):
+    def test_get_conn(
+        self,
+        mock_connect: MagicMock,
+        test_default_conn: Connection,
+        mocker: MockerFixture,
+    ):
+        # The exact-kwargs assertion below omits `extra_headers`, so the probe
+        # is pinned rather than inherited from whatever driver dependency
+        # resolution happened to install. Attribution has its own two tests;
+        # this one is about the connection arguments.
+        mocker.patch(
+            "airflow_providers_wherobots.hooks.sql._CONNECT_SUPPORTS_EXTRA_HEADERS",
+            False,
+        )
+
         # Instantiate hook
         hook = WherobotsSqlHook(
             runtime=Runtime.LARGE,

--- a/tests/unit_tests/test_client_attribution.py
+++ b/tests/unit_tests/test_client_attribution.py
@@ -36,7 +36,9 @@ def test_header_name_and_hop_format() -> None:
 def test_hop_is_within_the_length_bound() -> None:
     """The chain is bounded to 512 bytes, and tokens to 64 characters."""
     assert len(CLIENT_HOP.encode("utf-8")) <= 512
-    assert len("airflow") <= 64
+    # Asserted against the constant, not a copy of its current value, so that
+    # renaming the token to something over-long would actually fail here.
+    assert len(client_attribution.CLIENT_TOKEN) <= 64
 
 
 def test_unresolvable_version_falls_back_to_unknown(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/test_client_attribution.py
+++ b/tests/unit_tests/test_client_attribution.py
@@ -1,0 +1,75 @@
+"""
+Test the shared ``X-Wherobots-Client`` client-attribution hop.
+"""
+
+import importlib
+import re
+from importlib import metadata
+
+from pytest_mock import MockerFixture
+
+from airflow_providers_wherobots import client_attribution
+from airflow_providers_wherobots.client_attribution import (
+    CLIENT_HOP,
+    UNKNOWN_VERSION,
+    WHEROBOTS_CLIENT_HEADER,
+    client_attribution_header,
+)
+from airflow_providers_wherobots.hooks.base import PACKAGE_NAME
+
+# One hop: `client=<token>` plus zero or more `;key=value` params, where no
+# value may contain the `,` / `;` delimiters.
+HOP_PATTERN = re.compile(r"^client=[^,;]+(?:;[^,;=]+=[^,;]*)*$")
+
+
+def test_header_name_and_hop_format() -> None:
+    """The hook emits exactly one canonical header carrying one well-formed hop."""
+    header = client_attribution_header()
+    assert list(header) == [WHEROBOTS_CLIENT_HEADER]
+    assert WHEROBOTS_CLIENT_HEADER == "X-Wherobots-Client"
+
+    hop = header[WHEROBOTS_CLIENT_HEADER]
+    assert HOP_PATTERN.match(hop)
+    assert hop == f"client=airflow;ver={metadata.version(PACKAGE_NAME)}"
+
+
+def test_hop_is_within_the_length_bound() -> None:
+    """The chain is bounded to 512 bytes, and tokens to 64 characters."""
+    assert len(CLIENT_HOP.encode("utf-8")) <= 512
+    assert len("airflow") <= 64
+
+
+def test_unresolvable_version_falls_back_to_unknown(mocker: MockerFixture) -> None:
+    """A provider that isn't installed still emits a well-formed hop."""
+    mocker.patch.object(
+        client_attribution.metadata,
+        "version",
+        side_effect=metadata.PackageNotFoundError(PACKAGE_NAME),
+    )
+    assert client_attribution._resolve_provider_version() == UNKNOWN_VERSION
+
+    # The hop is built once at import, so reload the module under the patch to
+    # observe the header a never-installed provider would actually send.
+    try:
+        reloaded = importlib.reload(client_attribution)
+        assert reloaded.client_attribution_header() == {
+            WHEROBOTS_CLIENT_HEADER: "client=airflow;ver=unknown"
+        }
+        assert HOP_PATTERN.match(reloaded.CLIENT_HOP)
+    finally:
+        mocker.stopall()
+        importlib.reload(client_attribution)
+
+
+def test_delimiters_are_stripped_from_the_version(mocker: MockerFixture) -> None:
+    """A version can never smuggle a hop or field separator into the grammar."""
+    mocker.patch.object(
+        client_attribution.metadata, "version", return_value="1.0;0,dev"
+    )
+    try:
+        reloaded = importlib.reload(client_attribution)
+        assert reloaded.CLIENT_HOP == "client=airflow;ver=1.0_0_dev"
+        assert HOP_PATTERN.match(reloaded.CLIENT_HOP)
+    finally:
+        mocker.stopall()
+        importlib.reload(client_attribution)


### PR DESCRIPTION
## Summary

This provider had zero references to `X-Wherobots-Client`, so jobs submitted from a DAG showed up in
prod as unattributed traffic, indistinguishable from anything else. Both hooks now identify
themselves on the shared attribution chain with the origin hop `client=airflow;ver=<provider version>`.

Spec: [`studio-backend/docs/client-attribution.md`](https://github.com/wherobots/studio-backend/blob/main/docs/client-attribution.md).
The header is advisory, client-asserted, and never affects auth.

Linear: https://linear.app/wherobots/issue/WBC-819

## Changes

**`airflow_providers_wherobots/client_attribution.py` (new)** — one place that owns the hop.
Resolves the installed provider version once at import, falls back to `unknown` when the
distribution metadata is missing, and strips `,` / `;` from the version so a value can never break
the hop grammar.

**`hooks/rest_api.py`** — the REST hook reaches the platform directly, so it is the origin hop and
sends the header on every `_api_call`. Added a `default_headers` property so the User-Agent and the
attribution header are merged in one place.

**`hooks/sql.py`** — the SQL hook does *not* reach the platform directly; it delegates to
`wherobots-python-dbapi`. Rather than emitting the header itself, it passes its hop down through the
driver's `extra_headers`. The driver appends its own hop on the right, so the platform sees:

```
X-Wherobots-Client: client=airflow;ver=1.7.0, client=dbapi;ver=0.28.1
```

That preserves Airflow as the leftmost (origin) hop instead of letting the driver look like the
origin.

One wrinkle: `extra_headers` landed in `wherobots-python-dbapi` after 0.28.0 (dbapi #71) and is not
released yet, while this provider's floor is `>=0.28.0`. So the argument is probed via
`inspect.signature` rather than assumed. Against an older driver the provider works exactly as it
does today and just loses the Airflow hop. **Follow-up:** once a dbapi release with `extra_headers`
is out, raise the floor here and delete the probe.

The other follow-up is doc-only: `airflow` should be added to the canonical token vocabulary table in
`studio-backend/docs/client-attribution.md`. No backend change is needed to record it (the parser is
value-agnostic).

The first commit is a small `style:` commit that applies ruff's own lint/format fixes to
`rest_api.py`, which was already failing the repo's pre-commit hooks before this branch.

## Testing

New unit tests cover header presence, exact format, the delimiter guard, and the missing-version
fallback:

- `tests/unit_tests/test_client_attribution.py` — canonical header name, hop matches the grammar,
  512-byte bound, `ver=unknown` when the distribution is not installed, delimiters stripped.
- `tests/unit_tests/hooks/test_rest_api.py` — the header is actually on the wire (`responses`
  header matcher) and the User-Agent is still sent alongside it.
- `tests/unit_tests/hooks/test_sql.py` — the hop is handed to `connect(extra_headers=...)`, and is
  cleanly omitted on a driver that does not support it.

What I ran locally:

| Check | Result |
| --- | --- |
| `uv run pytest tests/unit_tests` | 51 passed |
| `pre-commit run ruff` (changed files) | pass |
| `pre-commit run ruff-format` (changed files) | pass |
| `pre-commit run mypy` (changed files) | 16 errors, identical to the `main` baseline. All pre-existing in `models.py` / `rest_api.py`, none in the new code. |

Not run: `tests/integration_tests`, which needs `PROD_API_TOKEN`. CI will run it.

`pre-commit run --all-files` fails on `main` today (6 x E701 in `wherobots/models.py`), so I ran the
hooks scoped to the changed files and diffed against the baseline rather than fixing unrelated files
in this PR.

<sub>- from Claude with ❤️</sub>
