### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airflow-providers-wherobots"
-version = "1.7.0"
+version = "1.8.0"
 description = "Airflow extension for communicating with Wherobots Cloud"
 authors = [{ name = "zongsi.zhang", email = "zongsi@wherobots.com" }]
 requires-python = ">=3.10, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "airflow-providers-wherobots"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Bumps the package version `1.7.0` → `1.8.0` ahead of the `v1.8.0` release tag. Version-only — no code, dependency, or workflow changes.

| File | Change |
| --- | --- |
| `pyproject.toml` | `[project].version` `1.7.0` → `1.8.0` |
| `uv.lock` | `airflow-providers-wherobots` self-entry `1.7.0` → `1.8.0` |

These are the only two places this package's version is declared. There is no `__version__` attribute: the runtime value is derived via `importlib.metadata.version()` in `client_attribution.py`, which both the `X-Wherobots-Client` header and the REST hook's User-Agent read from. `uv lock --locked` passes, so no further lock churn was needed.

## Why 1.8.0 (minor)

Two commits have landed since `v1.7.0`:

- **#62** — `chore`: refresh the dev `apache-airflow` lock to clear security alerts. Dev dependency group only; the published wheel still depends solely on `wherobots-python-dbapi` and `pydantic`, so no public-surface effect.
- **#64** — `feat`: emit the `X-Wherobots-Client` attribution header (WBC-819). Purely additive: a new module plus a new outbound header on both hooks. No signatures changed or removed, and it degrades silently on drivers without `extra_headers`.

Additive behavior, nothing broken and nothing merely fixed — minor, not patch or major. `wherobots-python-dbapi` v0.28.1 (shipped 2026-08-10) already carries the `extra_headers` support the header relies on, and the runtime floor stays at `>=0.28.0`, so there is no ordering constraint against the driver release.

This bump is also what makes the provider actually report itself: after it, the emitted header is `client=airflow;ver=1.8.0` (verified locally).

## Out of scope, noted for follow-up

- `client_attribution.py` has `ver=1.7.0` inside a module docstring and an inline comment. Both are illustrative examples of the header *format* — not a version source — and the paired `dbapi;ver=0.28.1` half would drift regardless. Left alone deliberately; the durable fix is genericizing them to `ver=<version>`, which is its own change.
- `CONTRIBUTING.md` step 1 still says to edit `[tool.poetry].version`. That key has not existed since the hatchling + uv migration; the correct location is `[project].version`, which this PR edits. Steps 2–4 (tag, push tag, CI validates) are still accurate.

## Verification

- `uv run pytest tests/unit_tests` — 51 passed.
- `uv lock --locked` — passes, lock consistent with `pyproject.toml`.
- `uv run python -c "...client_attribution_header()"` → `{'X-Wherobots-Client': 'client=airflow;ver=1.8.0'}`.
- Reviewed pre-push on both a standards and a spec axis; both clean.

## Release note

The `v1.8.0` tag is **not** pushed by this PR. `pypi-publish.yaml` fires on a `v[0-9]+.[0-9]+.[0-9]+` tag push and validates `uv version` against the tag name — that comparison resolves to `1.8.0` once this merges. Tagging is a separate step after merge.