### PR TITLE
chore: bump wherobots-python-dbapi pin to >=0.28.1 and version to 1.8.1

### DIFF
--- a/airflow_providers_wherobots/hooks/sql.py
+++ b/airflow_providers_wherobots/hooks/sql.py
@@ -2,9 +2,7 @@
 Hook for Wherobots' Spatial SQL API interface.
 """
 
-import inspect
-import logging
-from typing import Any, Dict, Final, Optional, Union
+from typing import Optional, Union
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from wherobots.db import Connection as WDBConnection, connect
@@ -17,37 +15,14 @@ from wherobots.db.region import Region
 from wherobots.db.runtime import Runtime
 from wherobots.db.session_type import SessionType
 
-from airflow_providers_wherobots.client_attribution import (
-    WHEROBOTS_CLIENT_HEADER,
-    client_attribution_header,
-)
+from airflow_providers_wherobots.client_attribution import client_attribution_header
 from airflow_providers_wherobots.hooks.base import DEFAULT_CONN_ID
 
 # This hook reaches the platform through the Python DB-API driver rather than
 # directly. The driver appends its own `client=dbapi;ver=...` hop to any
 # inbound `X-Wherobots-Client` chain, so handing it our hop via `extra_headers`
 # keeps Airflow as the leftmost (origin) hop instead of letting the driver look
-# like the origin.
-#
-# `extra_headers` is newer than this provider's `wherobots-python-dbapi>=0.28.0`
-# floor, so it is probed rather than assumed: against an older driver the
-# provider still works and simply loses the Airflow hop. Delete this probe and
-# pass the argument unconditionally once the floor is raised to a release that
-# has it.
-_CONNECT_SUPPORTS_EXTRA_HEADERS: Final[bool] = (
-    "extra_headers" in inspect.signature(connect).parameters
-)
-
-if not _CONNECT_SUPPORTS_EXTRA_HEADERS:
-    # Losing attribution is silent by design -- it must never fail a
-    # connection -- but silent and undiscoverable are different things. This is
-    # the one line that explains an Airflow-driven query showing up in the
-    # platform's analytics attributed to the driver instead of to Airflow.
-    logging.getLogger(__name__).debug(
-        "Installed wherobots-python-dbapi has no `extra_headers` argument; "
-        "omitting the %s hop for SQL connections.",
-        WHEROBOTS_CLIENT_HEADER,
-    )
+# like the origin. `extra_headers` is why the driver floor is pinned to 0.28.1.
 
 
 class WherobotsSqlHook(DbApiHook):  # type: ignore[misc]
@@ -82,11 +57,6 @@ class WherobotsSqlHook(DbApiHook):  # type: ignore[misc]
         self,
         runtime: Optional[Union[str, Runtime]] = None,
     ) -> WDBConnection:
-        attribution: Dict[str, Any] = (
-            {"extra_headers": client_attribution_header()}
-            if _CONNECT_SUPPORTS_EXTRA_HEADERS
-            else {}
-        )
         return connect(
             host=self._conn.host,
             api_key=self._conn.password,
@@ -97,7 +67,7 @@ class WherobotsSqlHook(DbApiHook):  # type: ignore[misc]
             read_timeout=self.read_timeout,
             force_new=self.force_new,
             session_type=self.session_type,
-            **attribution,
+            extra_headers=client_attribution_header(),
         )
 
     def get_conn(self) -> WDBConnection:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "airflow-providers-wherobots"
-version = "1.8.0"
+version = "1.8.1"
 description = "Airflow extension for communicating with Wherobots Cloud"
 authors = [{ name = "zongsi.zhang", email = "zongsi@wherobots.com" }]
 requires-python = ">=3.10, <3.13"
 readme = "README.md"
 dependencies = [
-    "wherobots-python-dbapi>=0.28.0",
+    "wherobots-python-dbapi>=0.28.1",
     "pydantic~=2.3",
 ]
 

--- a/tests/unit_tests/hooks/test_sql.py
+++ b/tests/unit_tests/hooks/test_sql.py
@@ -6,7 +6,6 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from airflow.models import Connection
-from pytest_mock import MockerFixture
 from wherobots.db.region import Region
 from wherobots.db.runtime import Runtime
 from wherobots.db.session_type import SessionType
@@ -24,17 +23,7 @@ class TestWherobotsSqlHook:
         self,
         mock_connect: MagicMock,
         test_default_conn: Connection,
-        mocker: MockerFixture,
     ):
-        # The exact-kwargs assertion below omits `extra_headers`, so the probe
-        # is pinned rather than inherited from whatever driver dependency
-        # resolution happened to install. Attribution has its own two tests;
-        # this one is about the connection arguments.
-        mocker.patch(
-            "airflow_providers_wherobots.hooks.sql._CONNECT_SUPPORTS_EXTRA_HEADERS",
-            False,
-        )
-
         # Instantiate hook
         hook = WherobotsSqlHook(
             runtime=Runtime.LARGE,
@@ -55,6 +44,7 @@ class TestWherobotsSqlHook:
             read_timeout=hook.read_timeout,
             force_new=True,
             session_type=SessionType.SINGLE,
+            extra_headers={WHEROBOTS_CLIENT_HEADER: CLIENT_HOP},
         )
 
     @mock.patch("airflow_providers_wherobots.hooks.sql.connect")
@@ -62,29 +52,9 @@ class TestWherobotsSqlHook:
         self,
         mock_connect: MagicMock,
         test_default_conn: Connection,
-        mocker: MockerFixture,
     ):
         """Our hop goes to the driver, which appends its own hop to the right."""
-        mocker.patch(
-            "airflow_providers_wherobots.hooks.sql._CONNECT_SUPPORTS_EXTRA_HEADERS",
-            True,
-        )
         WherobotsSqlHook().get_conn()
         assert mock_connect.call_args.kwargs["extra_headers"] == {
             WHEROBOTS_CLIENT_HEADER: CLIENT_HOP
         }
-
-    @mock.patch("airflow_providers_wherobots.hooks.sql.connect")
-    def test_get_conn_omits_client_attribution_on_older_drivers(
-        self,
-        mock_connect: MagicMock,
-        test_default_conn: Connection,
-        mocker: MockerFixture,
-    ):
-        """A driver without `extra_headers` still connects, just unattributed."""
-        mocker.patch(
-            "airflow_providers_wherobots.hooks.sql._CONNECT_SUPPORTS_EXTRA_HEADERS",
-            False,
-        )
-        WherobotsSqlHook().get_conn()
-        assert "extra_headers" not in mock_connect.call_args.kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -162,7 +162,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = "~=2.3" },
-    { name = "wherobots-python-dbapi", specifier = ">=0.28.0" },
+    { name = "wherobots-python-dbapi", specifier = ">=0.28.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1145,7 +1145,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1156,7 +1155,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1167,7 +1165,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -2949,7 +2946,7 @@ wheels = [
 
 [[package]]
 name = "wherobots-python-dbapi"
-version = "0.28.0"
+version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cbor2" },
@@ -2958,14 +2955,15 @@ dependencies = [
     { name = "pandas-stubs" },
     { name = "pyarrow" },
     { name = "requests" },
+    { name = "sqlparse" },
     { name = "strenum" },
     { name = "tenacity" },
     { name = "types-requests" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/65/6404abb4c2b8304b7653852797e8084114a2b943bcd6ba2abf2369ce41b8/wherobots_python_dbapi-0.28.0.tar.gz", hash = "sha256:6c157677e6d7078a395f02a185df83379fb9a8749908947ae71db22e0d0d9af9", size = 21050, upload-time = "2026-05-28T18:21:11.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/8b/a0429adcbc2b6d55b0f6674cf9f04af8dbacbfc444835054dd343ec64f2a/wherobots_python_dbapi-0.28.1.tar.gz", hash = "sha256:f285dbd1bc4efaedd9ddd59d783e7856d7eb9ea8969b377219a6f570d84b4d4a", size = 24624, upload-time = "2026-08-10T21:03:22.528Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/03/8adb81b736b30e6a70e87d3de90bb7a054be5ca664ed41303ade99fceecf/wherobots_python_dbapi-0.28.0-py3-none-any.whl", hash = "sha256:bfefa57ffac357beab5106ebdfd4a629d1ae8bb64c0137a3450767a321b2bbbf", size = 24167, upload-time = "2026-05-28T18:21:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/5632343602e65681b3f9b82ad90e95c7f8c730fc2d9b63b251754b5ecc92/wherobots_python_dbapi-0.28.1-py3-none-any.whl", hash = "sha256:1bee5d4c017171db05b9aff375d978485084a1628c2c0e7c601453d914f3e146", size = 27993, upload-time = "2026-08-10T21:03:21.326Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`1.8.0` shipped the `X-Wherobots-Client` header behind a runtime probe: the SQL hook checks whether the installed driver's `connect()` accepts `extra_headers` and quietly skips attribution when it does not. That was correct while the driver release was pending, but it means whether an Airflow-driven query is attributed to Airflow or to the driver depends on which driver version dependency resolution happens to pick.

`wherobots-python-dbapi` 0.28.1 is now on PyPI with `extra_headers`.

## Fix

Raise the floor to 0.28.1, delete the probe and its fallback branch, and pass `extra_headers` unconditionally. This is the cleanup the probe's own comment asked for.

## Verification

```
$ uv run pytest tests/unit_tests -q
50 passed
$ pre-commit run --files airflow_providers_wherobots/hooks/sql.py tests/unit_tests/hooks/test_sql.py pyproject.toml
ruff / ruff-format / mypy: Passed
```

`test_get_conn` now asserts `extra_headers` in its exact-kwargs comparison instead of pinning the probe to `False`, and the "older driver omits the header" test is gone with the branch it covered.

## Context

Wherobots' own MWAA environment is pinned at `>=1.7.0` and accounts for ~356 unattributed runs a week; wherobots/managed-airflow#99 moves it to 1.8.0. Customers on 1.4.x-1.7.0 (SatSure, ActionEngine, Overture Maps) are the other half of that gap.

---
Changes made by Claude Opus 5 in Claude Code.